### PR TITLE
Misc bugfixes

### DIFF
--- a/game.js
+++ b/game.js
@@ -356,7 +356,7 @@ function nextLoop() {
   requestAnimationFrame(timestamp => {
     if (!lastTime) lastTime = timestamp;
     const delta = timestamp - lastTime;
-    const frames = Math.floor(120 * delta / 1000);
+    const frames = Math.min(Math.floor(120 * delta / 1000), 60);
     if (frames > 0) {
       lastTime = timestamp;
     }

--- a/game.js
+++ b/game.js
@@ -242,8 +242,8 @@ function collisions() {
   // Stop at walls
   [ ...pacmans, ghost ].forEach(entity => {
     const box = convertSpriteToBox(entity);
-    box[0] += entity.vx * 3;
-    box[1] += entity.vy * 3;
+    box[0] += entity.vx * 2;
+    box[1] += entity.vy * 2;
     if (walls.some(wall => collides(wall, box))) {
       entity.vx = 0;
       entity.vy = 0;
@@ -276,8 +276,8 @@ function think() {
   });
   if (ghost.intent) {
     const box = convertSpriteToBox(ghost);
-    box[0] += ghost.intent.vx * 6;
-    box[1] += ghost.intent.vy * 6;
+    box[0] += ghost.intent.vx * 3;
+    box[1] += ghost.intent.vy * 3;
     if (!walls.some(wall => collides(wall, box))) {
       ghost.vx = ghost.intent.vx;
       ghost.vy = ghost.intent.vy;

--- a/game.js
+++ b/game.js
@@ -313,7 +313,8 @@ function consume() {
   });
   pellets = pellets.filter(dot => !chompBoxes.some(box => collides(box, [...dot, 1, 1 ])));
   // eats pacmen on ghost collision
-  chompBoxes.forEach((chompBox, index) => {
+  for (let index = chompBoxes.length - 1; index >= 0; index -= 1) {
+    const chompBox = chompBoxes[index];
     const ghostBox = convertSpriteToBox(ghost);
     if (collides(chompBox, ghostBox)) {
       if (pacmans[index].power || ghost.eaten) {
@@ -323,7 +324,7 @@ function consume() {
         wallet++;
       }
     }
-  });
+  }
   ghost.eaten = ghost.eaten || !dots.length;
 }
 

--- a/game.js
+++ b/game.js
@@ -287,7 +287,7 @@ function think() {
 }
 
 function spawn() {
-  if (counter % 600 === 0) {
+  if (counter % 600 === 0 && pacmans.length < 256) {
     pacmans.push({ x: 0, y: 114, vx: -1, vy: 0, power: 600 });
     pacmans.push({ x: 0, y: 114, vx: 1, vy: 0, power: 600 });
   }


### PR DESCRIPTION
1. Reduce magnitude of "anticipatory collision detection". This is to disallow wiggling in hallways, but could result in [getting stuck](https://ldjam.com/events/ludum-dare/44/$148109/boo) at the lower end of the ghost house on a certain series of inputs.
2. Add a maximum to the number of game frames that get handled per animation frame, so that the browser doesn't stall if I leave and come back
3. Similarly, enforce a maximum pacman count
4. Eat pacmans in reverse order, so that array indexes remain stable between `chompBoxes` and `pacmans` (for purposes of splice); fixes a crash on eating two pacmans in one frame